### PR TITLE
Fix calculating checksum

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -17,7 +17,7 @@ console.log(udp.encode({
 output:
 
 ```
-<Buffer e6 38 00 50 00 10 52 1f 77 68 61 74 65 76 65 72>
+<Buffer e6 38 00 50 00 10 61 7d 77 68 61 74 65 76 65 72>
 ```
 
 # decode example
@@ -73,7 +73,7 @@ Decode a given a UDP data packet `buf`:
 * `packet.sourcePort`
 * `packet.destinationPort`
 * `packet.length` - length of total udp packet, including 8 byte header
-* `packet.checksum` - does not yet match measured values
+* `packet.checksum`
 * `packet.data`
 
 ## var sum = udp.checksum(packet, buffer)

--- a/readme.markdown
+++ b/readme.markdown
@@ -60,7 +60,7 @@ Encode a `packet`:
 * `packet.destinationPort`
 * `packet.data` - buffer payload
 
-Optionally, for checksums (not currently working):
+Optionally, for checksums:
 
 * `packet.sourceIp` - ipv4 address string or 4-byte buffer
 * `packet.destinationIp` - ipv4 address string or 4-byte buffer
@@ -76,7 +76,7 @@ Decode a given a UDP data packet `buf`:
 * `packet.checksum` - does not yet match measured values
 * `packet.data`
 
-## var sum = udp.checksum(packet)
+## var sum = udp.checksum(packet, buffer)
 
 Return the checksum for a decoded `packet`.
 

--- a/test/decode.js
+++ b/test/decode.js
@@ -39,8 +39,9 @@ test('decode a real packet', function (t) {
 test('verify checksum from real packet', function (t) {
   var ipPacket = ip.decode(data)
   var udpPacket = udp.decode(ipPacket.data)
+
   t.equal(
-    udp.checksum(xtend(ipPacket, udpPacket)),
+    udp.checksum(xtend(ipPacket, udpPacket), ipPacket.data),
     udpPacket.checksum
   )
   t.end()

--- a/test/encode.js
+++ b/test/encode.js
@@ -1,0 +1,15 @@
+var udp = require('../')
+var test = require('tape')
+
+test('verify an encoded packets checksum, matches a real one', function (t) {
+  var packet = udp.encode({
+    sourceIp: '100.96.0.21',
+    sourcePort: 52133,
+    destinationIp: '1.1.1.1',
+    destinationPort: 1111,
+    data: Buffer.from('hello world')
+  })
+  const checksum = packet.readUInt16BE(6)
+  t.equal(checksum, 0x3786)
+  t.end()
+})


### PR DESCRIPTION
This PR fixes calculating the checksum. Before it was done incorrectly (which was also documented).

Note that it changes the interface from `udp.checksum(packet)` to `udp.checksum(packet, buffer)`, but this is needed as one of the issues before is that the checksum did not read the entire buffer, but only the data part. It also didn't read the `srcip` which I have also added.